### PR TITLE
[FEAT] Todo 삭제 기능 구현 및 생성 기능 수정

### DIFF
--- a/N_VoiceMemoApp_SwiftUI/Todo/Create/TodoCreateView.swift
+++ b/N_VoiceMemoApp_SwiftUI/Todo/Create/TodoCreateView.swift
@@ -13,6 +13,7 @@ struct TodoCreateView: View {
     
     @State private var todoTitle: String = ""
     @State private var todoTime = Date()
+    @State private var showingAlert = false
     var formattedToday: String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
@@ -25,6 +26,13 @@ struct TodoCreateView: View {
             TodoCreateMainView(todoTitle: $todoTitle, todoTime: $todoTime, formattedToday: formattedToday)
             
             Button {
+                
+                
+                guard !todoTitle.trimmingCharacters(in: .whitespaces).isEmpty else {
+                    showingAlert = true
+                    return
+                }
+                
                 let newTodo = todo(
                     id: UUID().uuidString,
                     title: todoTitle,
@@ -52,6 +60,13 @@ struct TodoCreateView: View {
             .padding(.bottom, Constants.ControlHeight * 50)
             
             
+        }
+        .alert(isPresented: $showingAlert) {
+            Alert(
+                title: Text("제목을 입력해주세요."),
+                message: Text("할 일을 추가하려면 제목이 필요합니다."),
+                dismissButton: .default(Text("확인"))
+            )
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/N_VoiceMemoApp_SwiftUI/Todo/Main/TodoMainView.swift
+++ b/N_VoiceMemoApp_SwiftUI/Todo/Main/TodoMainView.swift
@@ -63,6 +63,8 @@ struct TodoMainView: View {
 
 struct TodoListView: View {
     @ObservedObject var viewModel: TodoMainViewModel
+    @State private var showingDeleteAlert = false
+    @State private var selectedTodoID: String?
     
     var body: some View {
         VStack(spacing: 0) {
@@ -102,11 +104,27 @@ struct TodoListView: View {
                                 .foregroundColor(.iconOn)
                         }
                         .padding(.leading, Constants.ControlWidth * 19)
+                        .onLongPressGesture {
+                                    selectedTodoID = todo.id
+                                    showingDeleteAlert = true
+                                }
                         
                         Spacer()
                     }
                     .padding(.top, Constants.ControlHeight * 10)
                     .padding(.bottom, Constants.ControlHeight * 10)
+                    .alert(isPresented: $showingDeleteAlert) {
+                        Alert(
+                            title: Text("삭제하시겠습니까?"),
+                            message: Text("\(todo.title) 할 일을 삭제하면\n복구할 수 없습니다."),
+                            primaryButton: .destructive(Text("삭제")) {
+                                if let id = selectedTodoID {
+                                    viewModel.process(.deleteTodo(id))
+                                }
+                            },
+                            secondaryButton: .cancel(Text("취소"))
+                        )
+                    }
                     
                     Rectangle()
                         .fill(Color.gray1)

--- a/N_VoiceMemoApp_SwiftUI/Todo/Main/TodoMainViewModel.swift
+++ b/N_VoiceMemoApp_SwiftUI/Todo/Main/TodoMainViewModel.swift
@@ -34,7 +34,7 @@ final class TodoMainViewModel: ObservableObject {
         case let .isCompleteToggle(id):
             print(id)
         case let .deleteTodo(id):
-            print(id)
+            deleteTodo(id)
         }
     }
     
@@ -81,6 +81,25 @@ extension TodoMainViewModel {
                 self.todoViewModels = sortedResponse.map {
                     todo(id: $0.id, title: $0.title, date: $0.date, time: $0.time, isCompleted: $0.isCompleted)
                 }
+            }
+        }
+    }
+    
+    private func deleteTodo(_ id: String) {
+        Task {
+            let db = Firestore.firestore()
+            let docRef = db.collection("Todo").document("List")
+            
+            do {
+                let snapshot = try await docRef.getDocument()
+                guard var response = try? snapshot.data(as: TodoResponse.self) else { return }
+                
+                response.todo.removeAll { $0.id == id }
+                
+                try docRef.setData(from: response)
+                process(.loadData) // 다시 불러와서 갱신
+            } catch {
+                print("삭제 실패: \(error)")
             }
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
1. [FEAT] Todo 삭제 기능 구현 및 생성 기능 수정 #9

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. Todo 삭제 기능 구현 
2. Todo 생성 기능 수정

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. Todo 삭제 기능 구현 
```Swift
.alert(isPresented: $showingDeleteAlert) {
                        Alert(
                            title: Text("삭제하시겠습니까?"),
                            message: Text("\(todo.title) 할 일을 삭제하면\n복구할 수 없습니다."),
                            primaryButton: .destructive(Text("삭제")) {
                                if let id = selectedTodoID {
                                    viewModel.process(.deleteTodo(id))
                                }
                            },
                            secondaryButton: .cancel(Text("취소"))
                        )
                    }
```
2. Todo 생성 기능 수정
```Swift
guard !todoTitle.trimmingCharacters(in: .whitespaces).isEmpty else {
                    showingAlert = true
                    return
                }
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
